### PR TITLE
Set proper LDFLAGS on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ LD = gcc
 LDFLAGS =
 LIBS = -L../../lib -lxmp -lm
 
+ifeq (Darwin,$(shell uname -s))
+	LDFLAGS := -framework Cocoa -lSDLmain
+endif
+
 all: xmdp
 
 xmdp: mdp.o font1.o font2.o


### PR DESCRIPTION
SDL on OS X requires two extra linker flags to work properly:

```
-framework Cocoa # to link against the core OS Cocoa libraries
-lSDLMain # mandatory for SDL on OS X
```

This patch updates the Makefile to add these to LDFLAGS on Darwin.
