### PR TITLE
update Makefile for Homebrew on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ LIBS = -lxmp -lSDL2
 ifeq (Darwin,$(shell uname -s))
 	CFLAGS += -I/usr/local/include
 	LDFLAGS += -framework Cocoa -L/usr/local/lib
+	# for Homebrew, nobody installs SDL to /usr/local anymore on MacOS
+	CFLAGS += -I/opt/homebrew/include
+	LDFLAGS += -L/opt/homebrew/lib
 endif
 
 .c.o:


### PR DESCRIPTION
Most people willing to play around with xmdp on MacOS typically install SDL through Homebrew these days, which needs CFLAGS/LDFLAGS modifications.